### PR TITLE
feat: extend calendar API to fetch three months of data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ app.get('/', (c) => {
   });
 });
 
-/** Get current month calendar data (JSON) */
+/** Get three months calendar data (JSON) - previous, current, and next month */
 app.get('/api/calendar', async (c) => {
   const env = c.env;
   const authService = new AuthService(env);
@@ -61,49 +61,35 @@ app.get('/api/calendar', async (c) => {
   const shouldUpdate = await calendarService.shouldUpdateCalendar();
 
   if (shouldUpdate) {
-    const now = new Date();
-    const year = now.getFullYear().toString();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-
-    const calendarData = await calendarService.fetchMonthCalendar(year, month);
-
-    if (calendarData) {
-      const stored = await calendarService.storeCalendarData(calendarData);
-      if (stored) {
-        await calendarService.updateLastFetchTime();
-      }
+    const refreshResult = await calendarService.refreshThreeMonthsCalendar();
+    if (refreshResult.success) {
+      await calendarService.updateLastFetchTime();
     }
   }
 
-  const calendarData = await calendarService.getCurrentMonthCalendar();
+  const calendarData = await calendarService.getThreeMonthsCalendar();
   return json(c, calendarData, { cache: CACHE.MEDIUM });
 });
 
-/** Force refresh calendar data */
+/** Force refresh calendar data for three months */
 app.get('/api/calendar/refresh', async (c) => {
   const env = c.env;
   const authService = new AuthService(env);
   const calendarService = new CalendarService(env, authService);
 
-  const now = new Date();
-  const year = now.getFullYear().toString();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const refreshResult = await calendarService.refreshThreeMonthsCalendar();
 
-  const calendarData = await calendarService.fetchMonthCalendar(year, month);
-
-  if (!calendarData) {
-    return error(c, 'Failed to fetch calendar data from upstream API');
-  }
-
-  const stored = await calendarService.storeCalendarData(calendarData);
-
-  if (!stored) {
-    return error(c, 'Failed to store calendar data');
+  if (!refreshResult.success) {
+    return error(c, 'Failed to refresh calendar data from upstream API');
   }
 
   await calendarService.updateLastFetchTime();
 
-  return success(c, { refreshed: true }, 'Calendar data refreshed successfully');
+  return success(c, {
+    refreshed: true,
+    monthsRefreshed: refreshResult.monthsRefreshed,
+    monthsFailed: refreshResult.monthsFailed,
+  }, `Calendar data refreshed successfully (${refreshResult.monthsRefreshed} months)`);
 });
 
 /** ICS calendar export - supports filtering by city/cinema/hall */
@@ -119,12 +105,21 @@ app.get('/*', async (c) => {
   const authService = new AuthService(env);
   const calendarService = new CalendarService(env, authService);
 
+  // Check if we need to refresh data (same logic as /api/calendar)
+  const shouldUpdate = await calendarService.shouldUpdateCalendar();
+  if (shouldUpdate) {
+    const refreshResult = await calendarService.refreshThreeMonthsCalendar();
+    if (refreshResult.success) {
+      await calendarService.updateLastFetchTime();
+    }
+  }
+
   // Parse location codes from path
   const { cityCode, cinemaCode, hallCode } = parseIcsPath(pathname);
   const title = buildCalendarTitle(cityCode, cinemaCode, hallCode);
 
-  // Get calendar data
-  const calendarData = await calendarService.getCurrentMonthCalendar();
+  // Get calendar data (three months)
+  const calendarData = await calendarService.getThreeMonthsCalendar();
   const events = calendarData.events || [];
 
   // Filter by location
@@ -145,32 +140,21 @@ app.get('/*', async (c) => {
 // ============================================================================
 
 async function handleScheduled(env: Env): Promise<void> {
-  console.log('[Scheduled] Running calendar refresh');
+  console.log('[Scheduled] Running calendar refresh for three months');
 
   const authService = new AuthService(env);
   const calendarService = new CalendarService(env, authService);
 
-  const now = new Date();
-  const year = now.getFullYear().toString();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-
   try {
-    const calendarData = await calendarService.fetchMonthCalendar(year, month);
+    const refreshResult = await calendarService.refreshThreeMonthsCalendar();
 
-    if (!calendarData) {
-      console.error('[Scheduled] Failed to fetch calendar data');
-      return;
-    }
-
-    const stored = await calendarService.storeCalendarData(calendarData);
-
-    if (!stored) {
-      console.error('[Scheduled] Failed to store calendar data');
+    if (!refreshResult.success) {
+      console.error('[Scheduled] Failed to refresh any calendar data');
       return;
     }
 
     await calendarService.updateLastFetchTime();
-    console.log(`[Scheduled] Successfully refreshed calendar for ${year}-${month}`);
+    console.log(`[Scheduled] Successfully refreshed ${refreshResult.monthsRefreshed} months (${refreshResult.monthsFailed} failed)`);
   } catch (err) {
     console.error('[Scheduled] Error:', err);
   }

--- a/src/services.ts
+++ b/src/services.ts
@@ -12,6 +12,40 @@ import { AuthError, DatabaseError } from './utils/errors';
 /** Cache duration for calendar data (12 hours in ms) */
 const CACHE_DURATION_MS = 12 * 60 * 60 * 1000;
 
+/** Represents a year-month tuple */
+interface YearMonth {
+  year: number;
+  month: number;
+}
+
+/**
+ * Get three consecutive months: previous, current, and next
+ * Handles year boundaries correctly (e.g., January -> December of previous year)
+ */
+export function getThreeMonthRange(referenceDate: Date = new Date()): {
+  previous: YearMonth;
+  current: YearMonth;
+  next: YearMonth;
+} {
+  const year = referenceDate.getFullYear();
+  const month = referenceDate.getMonth() + 1; // 1-indexed
+
+  // Previous month
+  const previous: YearMonth = month === 1
+    ? { year: year - 1, month: 12 }
+    : { year, month: month - 1 };
+
+  // Current month
+  const current: YearMonth = { year, month };
+
+  // Next month
+  const next: YearMonth = month === 12
+    ? { year: year + 1, month: 1 }
+    : { year, month: month + 1 };
+
+  return { previous, current, next };
+}
+
 /**
  * Authentication service for managing API tokens
  */
@@ -109,9 +143,16 @@ export class CalendarService {
 
   /**
    * Store calendar data using batched D1 operations for performance
+   * @param calendarData - The calendar response from API
+   * @param targetYear - The year for the data (defaults to current year)
+   * @param targetMonth - The month for the data (defaults to current month)
    * @throws {DatabaseError} When database operations fail
    */
-  async storeCalendarData(calendarData: CalendarResponse): Promise<boolean> {
+  async storeCalendarData(
+    calendarData: CalendarResponse,
+    targetYear?: number,
+    targetMonth?: number
+  ): Promise<boolean> {
     if (!calendarData.data?.list?.length) {
       return false;
     }
@@ -119,8 +160,8 @@ export class CalendarService {
     const { list } = calendarData.data;
     const timestamp = new Date().toISOString();
     const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
+    const year = targetYear ?? now.getFullYear();
+    const month = targetMonth ?? (now.getMonth() + 1);
 
     try {
       const db = this.env.DB;
@@ -173,7 +214,68 @@ export class CalendarService {
   }
 
   /**
+   * Fetch multiple months of calendar data in parallel
+   * Note: fetchMonthCalendar() internally catches all errors and returns null on failure,
+   * so Promise.all() is safe here - promises never reject.
+   */
+  async fetchMultipleMonths(months: { year: number; month: number }[]): Promise<{
+    results: { year: number; month: number; data: CalendarResponse | null; success: boolean }[];
+    successCount: number;
+    failureCount: number;
+  }> {
+    const results = await Promise.all(
+      months.map(async ({ year, month }) => {
+        const yearStr = year.toString();
+        const monthStr = String(month).padStart(2, '0');
+        const data = await this.fetchMonthCalendar(yearStr, monthStr);
+        return { year, month, data, success: data !== null };
+      })
+    );
+
+    return {
+      results,
+      successCount: results.filter(r => r.success).length,
+      failureCount: results.filter(r => !r.success).length,
+    };
+  }
+
+  /**
+   * Refresh calendar data for three months (previous, current, next)
+   * Partial failures are tolerated - successful months are still stored
+   */
+  async refreshThreeMonthsCalendar(): Promise<{
+    success: boolean;
+    monthsRefreshed: number;
+    monthsFailed: number;
+  }> {
+    const range = getThreeMonthRange();
+    const months = [range.previous, range.current, range.next];
+
+    const fetchResult = await this.fetchMultipleMonths(months);
+
+    // Store sequentially to avoid D1 concurrent write issues.
+    // Each storeCalendarData() executes a batch of statements that may conflict
+    // if run in parallel (e.g., DELETE + INSERT on same dates).
+    let storedCount = 0;
+    for (const result of fetchResult.results) {
+      if (result.success && result.data) {
+        const stored = await this.storeCalendarData(result.data, result.year, result.month);
+        if (stored) {
+          storedCount++;
+        }
+      }
+    }
+
+    return {
+      success: storedCount > 0,
+      monthsRefreshed: storedCount,
+      monthsFailed: fetchResult.failureCount + (fetchResult.successCount - storedCount),
+    };
+  }
+
+  /**
    * Get current month's calendar data from D1
+   * @deprecated Use getThreeMonthsCalendar() instead for better coverage
    */
   async getCurrentMonthCalendar(): Promise<{ days: CalendarDay[]; events: CalendarEvent[] }> {
     const now = new Date();
@@ -197,7 +299,34 @@ export class CalendarService {
   }
 
   /**
-   * Check if calendar data needs refresh (stale after 12 hours)
+   * Get three months of calendar data from D1 (previous, current, next month)
+   */
+  async getThreeMonthsCalendar(): Promise<{ days: CalendarDay[]; events: CalendarEvent[] }> {
+    const range = getThreeMonthRange();
+    const months = [range.previous, range.current, range.next];
+
+    try {
+      // Build WHERE clause for three months
+      const monthConditions = months.map(() => '(year = ? AND month = ?)').join(' OR ');
+      const bindings = months.flatMap(m => [m.year, m.month]);
+
+      const [daysResult, eventsResult] = await this.env.DB.batch([
+        this.env.DB.prepare(`SELECT * FROM calendar_days WHERE ${monthConditions} ORDER BY year ASC, month ASC, day ASC`).bind(...bindings),
+        this.env.DB.prepare(`SELECT * FROM calendar_events WHERE ${monthConditions} ORDER BY screen_start_time ASC`).bind(...bindings),
+      ]);
+
+      return {
+        days: (daysResult.results as unknown as CalendarDay[]) || [],
+        events: (eventsResult.results as unknown as CalendarEvent[]) || [],
+      };
+    } catch (error) {
+      console.error('[CalendarService] Query failed:', error);
+      return { days: [], events: [] };
+    }
+  }
+
+  /**
+   * Check if calendar data needs refresh (stale after 12 hours or missing any of three months)
    */
   async shouldUpdateCalendar(): Promise<boolean> {
     try {
@@ -209,13 +338,20 @@ export class CalendarService {
         return true;
       }
 
-      // Also check if we have data for current month
-      const currentDate = new Date();
-      const result = await this.env.DB.prepare(
-        'SELECT COUNT(*) as count FROM calendar_days WHERE year = ? AND month = ?'
-      ).bind(currentDate.getFullYear(), currentDate.getMonth() + 1).first<{ count: number }>();
+      // Check if we have data for all three months in a single query
+      const range = getThreeMonthRange();
+      const months = [range.previous, range.current, range.next];
+      const bindings = months.flatMap(m => [m.year, m.month]);
 
-      return !result || result.count === 0;
+      // Count distinct year-month combinations that have data
+      const result = await this.env.DB.prepare(`
+        SELECT COUNT(DISTINCT year || '-' || month) as month_count
+        FROM calendar_days
+        WHERE (year = ? AND month = ?) OR (year = ? AND month = ?) OR (year = ? AND month = ?)
+      `).bind(...bindings).first<{ month_count: number }>();
+
+      // Need all 3 months to have data
+      return !result || result.month_count < 3;
     } catch {
       return true; // Default to updating on error
     }

--- a/test/unit/services.spec.ts
+++ b/test/unit/services.spec.ts
@@ -3,8 +3,45 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestEnv } from '../setup/mocks';
 import { loginResponses, calendarResponses } from '../setup/fixtures';
-import { AuthService, CalendarService } from '../../src/services';
+import { AuthService, CalendarService, getThreeMonthRange } from '../../src/services';
 import { AuthError } from '../../src/utils/errors';
+
+describe('getThreeMonthRange()', () => {
+  it('should return correct range for a mid-year month', () => {
+    const date = new Date('2026-06-15');
+    const range = getThreeMonthRange(date);
+
+    expect(range.previous).toEqual({ year: 2026, month: 5 });
+    expect(range.current).toEqual({ year: 2026, month: 6 });
+    expect(range.next).toEqual({ year: 2026, month: 7 });
+  });
+
+  it('should handle January (previous month is December of previous year)', () => {
+    const date = new Date('2026-01-15');
+    const range = getThreeMonthRange(date);
+
+    expect(range.previous).toEqual({ year: 2025, month: 12 });
+    expect(range.current).toEqual({ year: 2026, month: 1 });
+    expect(range.next).toEqual({ year: 2026, month: 2 });
+  });
+
+  it('should handle December (next month is January of next year)', () => {
+    const date = new Date('2026-12-15');
+    const range = getThreeMonthRange(date);
+
+    expect(range.previous).toEqual({ year: 2026, month: 11 });
+    expect(range.current).toEqual({ year: 2026, month: 12 });
+    expect(range.next).toEqual({ year: 2027, month: 1 });
+  });
+
+  it('should use current date when no argument provided', () => {
+    const now = new Date();
+    const range = getThreeMonthRange();
+
+    expect(range.current.year).toBe(now.getFullYear());
+    expect(range.current.month).toBe(now.getMonth() + 1);
+  });
+});
 
 describe('AuthService', () => {
   let testEnv: ReturnType<typeof createTestEnv>;
@@ -266,6 +303,146 @@ describe('CalendarService', () => {
 
       consoleError.mockRestore();
     });
+
+    it('should accept targetYear and targetMonth parameters', async () => {
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.storeCalendarData(calendarResponses.valid, 2025, 12);
+
+      expect(result).toBe(true);
+
+      // Verify queries include the specified year/month
+      const queries = testEnv.mockD1.getExecutedQueries();
+      const fetchLogQuery = queries.find(q => q.sql.includes('fetch_logs'));
+      expect(fetchLogQuery).toBeDefined();
+      expect(fetchLogQuery?.bindings).toContain(2025);
+      expect(fetchLogQuery?.bindings).toContain(12);
+    });
+  });
+
+  describe('fetchMultipleMonths()', () => {
+    it('should fetch multiple months in parallel', async () => {
+      testEnv.mockFetch.setResponse(/getCalendar/, new Response(JSON.stringify(calendarResponses.valid)));
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.fetchMultipleMonths([
+        { year: 2026, month: 1 },
+        { year: 2026, month: 2 },
+      ]);
+
+      expect(result.results).toHaveLength(2);
+      expect(result.successCount).toBe(2);
+      expect(result.failureCount).toBe(0);
+    });
+
+    it('should handle partial failures gracefully', async () => {
+      // First call succeeds, second fails
+      testEnv.mockFetch.setResponse(/getCalendar/, [
+        new Response(JSON.stringify(calendarResponses.valid)),
+        new Response(JSON.stringify(calendarResponses.invalidData)),
+      ]);
+
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.fetchMultipleMonths([
+        { year: 2026, month: 1 },
+        { year: 2026, month: 2 },
+      ]);
+
+      expect(result.results).toHaveLength(2);
+      expect(result.successCount).toBe(1);
+      expect(result.failureCount).toBe(1);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('refreshThreeMonthsCalendar()', () => {
+    it('should refresh three months of data', async () => {
+      testEnv.mockFetch.setResponse(/getCalendar/, new Response(JSON.stringify(calendarResponses.valid)));
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.refreshThreeMonthsCalendar();
+
+      expect(result.success).toBe(true);
+      expect(result.monthsRefreshed).toBe(3);
+      expect(result.monthsFailed).toBe(0);
+    });
+
+    it('should succeed even if some months fail', async () => {
+      // Two succeed, one fails
+      testEnv.mockFetch.setResponse(/getCalendar/, [
+        new Response(JSON.stringify(calendarResponses.valid)),
+        new Response(JSON.stringify(calendarResponses.invalidData)),
+        new Response(JSON.stringify(calendarResponses.valid)),
+      ]);
+
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.refreshThreeMonthsCalendar();
+
+      expect(result.success).toBe(true);
+      expect(result.monthsRefreshed).toBe(2);
+      expect(result.monthsFailed).toBe(1);
+
+      consoleError.mockRestore();
+    });
+
+    it('should return failure if all months fail', async () => {
+      testEnv.mockFetch.setResponse(/getCalendar/, new Response(JSON.stringify(calendarResponses.invalidData)));
+
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.refreshThreeMonthsCalendar();
+
+      expect(result.success).toBe(false);
+      expect(result.monthsRefreshed).toBe(0);
+      expect(result.monthsFailed).toBe(3);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getThreeMonthsCalendar()', () => {
+    it('should return days and events for three months', async () => {
+      const mockDays = [
+        { day: 1, month: 12, year: 2025 },
+        { day: 15, month: 1, year: 2026 },
+        { day: 28, month: 2, year: 2026 },
+      ];
+      const mockEvents = [
+        { id: 1, show_name: 'Movie 1' },
+        { id: 2, show_name: 'Movie 2' },
+      ];
+
+      testEnv.mockD1.setBatchResults([
+        { results: mockDays, success: true },
+        { results: mockEvents, success: true },
+      ]);
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.getThreeMonthsCalendar();
+
+      expect(result.days).toEqual(mockDays);
+      expect(result.events).toEqual(mockEvents);
+    });
+
+    it('should return empty arrays on database error', async () => {
+      testEnv.mockD1.setQueryResult('SELECT', () => {
+        throw new Error('Query timeout');
+      });
+
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.getThreeMonthsCalendar();
+
+      expect(result).toEqual({ days: [], events: [] });
+
+      consoleError.mockRestore();
+    });
   });
 
   describe('getCurrentMonthCalendar()', () => {
@@ -320,11 +497,12 @@ describe('CalendarService', () => {
       expect(result).toBe(true);
     });
 
-    it('should return false when data is fresh and exists', async () => {
+    it('should return false when data is fresh and all three months have data', async () => {
       testEnv.mockKV.setData('last_fetch', {
         time: Date.now() - 1000, // 1 second ago
       });
-      testEnv.mockD1.setQueryResult('SELECT COUNT', { count: 10 });
+      // Mock: all 3 months have data (month_count = 3)
+      testEnv.mockD1.setQueryResult('SELECT COUNT', { month_count: 3 });
 
       const service = new CalendarService(testEnv.env, authService);
       const result = await service.shouldUpdateCalendar();
@@ -332,11 +510,36 @@ describe('CalendarService', () => {
       expect(result).toBe(false);
     });
 
+    it('should return true when fetch is fresh but only 2 months have data', async () => {
+      testEnv.mockKV.setData('last_fetch', {
+        time: Date.now() - 1000,
+      });
+      // Mock: only 2 out of 3 months have data
+      testEnv.mockD1.setQueryResult('SELECT COUNT', { month_count: 2 });
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.shouldUpdateCalendar();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when fetch is fresh but only 1 month has data', async () => {
+      testEnv.mockKV.setData('last_fetch', {
+        time: Date.now() - 1000,
+      });
+      testEnv.mockD1.setQueryResult('SELECT COUNT', { month_count: 1 });
+
+      const service = new CalendarService(testEnv.env, authService);
+      const result = await service.shouldUpdateCalendar();
+
+      expect(result).toBe(true);
+    });
+
     it('should return true when fetch is fresh but no data exists', async () => {
       testEnv.mockKV.setData('last_fetch', {
         time: Date.now() - 1000,
       });
-      testEnv.mockD1.setQueryResult('SELECT COUNT', { count: 0 });
+      testEnv.mockD1.setQueryResult('SELECT COUNT', { month_count: 0 });
 
       const service = new CalendarService(testEnv.env, authService);
       const result = await service.shouldUpdateCalendar();
@@ -361,6 +564,23 @@ describe('CalendarService', () => {
       const result = await service.shouldUpdateCalendar();
 
       expect(result).toBe(true);
+    });
+
+    it('should use single query to check all three months', async () => {
+      testEnv.mockKV.setData('last_fetch', {
+        time: Date.now() - 1000,
+      });
+      testEnv.mockD1.setQueryResult('SELECT COUNT', { month_count: 3 });
+
+      const service = new CalendarService(testEnv.env, authService);
+      await service.shouldUpdateCalendar();
+
+      // Verify only one DB query was made (not three separate queries)
+      const queries = testEnv.mockD1.getExecutedQueries();
+      const countQueries = queries.filter(q => q.sql.includes('COUNT'));
+      expect(countQueries).toHaveLength(1);
+      // Verify the query checks all three months
+      expect(countQueries[0].sql).toContain('DISTINCT');
     });
   });
 


### PR DESCRIPTION
## Summary
- Extends calendar API to fetch previous, current, and next month instead of just current month
- Provides better coverage around month boundaries for users viewing schedules near the start/end of months
- Adds parallel fetching for improved performance when refreshing multiple months

## Changes
- Add `getThreeMonthRange()` helper with proper year boundary handling (January → December of previous year)
- Add `fetchMultipleMonths()` for parallel API calls
- Add `refreshThreeMonthsCalendar()` and `getThreeMonthsCalendar()` service methods
- Update `shouldUpdateCalendar()` to verify all three months have data
- Update all endpoints (`/api/calendar`, `/api/calendar/refresh`, ICS export) and scheduled handler

## Test plan
- [x] Unit tests added for `getThreeMonthRange()` including year boundary cases
- [x] Unit tests added for `fetchMultipleMonths()` including partial failure scenarios
- [x] Unit tests added for `refreshThreeMonthsCalendar()` 
- [x] Unit tests added for `getThreeMonthsCalendar()`
- [x] Unit tests updated for `shouldUpdateCalendar()` three-month logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)