### PR TITLE
feat: add third-party movie platform links

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -55,6 +55,16 @@ CREATE TABLE IF NOT EXISTS calendar_events
     cover_img1
     TEXT,    -- poster/cover image URL
 
+    -- TMDb integration fields
+    tmdb_id
+    INTEGER, -- TMDb movie ID
+    imdb_id
+    TEXT,    -- IMDb ID (e.g., tt1234567)
+    tmdb_lookup_status
+    TEXT
+    DEFAULT
+    'pending', -- 'pending' | 'found' | 'not_found' | 'error'
+
     -- Additional fields for our database
     date
     TEXT

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -7,6 +7,7 @@
 import { createEvents, type EventAttributes, type DurationObject } from 'ics';
 import { CFA } from './config';
 import type { CalendarEvent } from './models';
+import { generateMovieLinks, formatMovieLinksForDescription } from './utils/movie-links';
 
 /** Parsed location info from event */
 interface ParsedLocation {
@@ -107,10 +108,15 @@ function toIcsEvent(event: CalendarEvent, calendarTitle: string): EventAttribute
 
   const location = parseLocation(event.screen_cinema);
 
+  // Generate movie platform links
+  const movieLinks = generateMovieLinks(event.show_name, event.film_year, event.imdb_id);
+
   const description = [
     event.film_type,
     event.film_area ? `/ ${event.film_area}` : '',
     event.activity ? `\n${event.activity}` : '',
+    '\n---',
+    formatMovieLinksForDescription(movieLinks),
   ]
     .filter(Boolean)
     .join(' ');
@@ -133,7 +139,7 @@ function toIcsEvent(event: CalendarEvent, calendarTitle: string): EventAttribute
     description,
     location: location.displayLocation,
     geo: location.geo,
-    url: `https://search.douban.com/movie/subject_search?search_text=${encodeURIComponent(event.show_name)}`,
+    url: movieLinks.imdb,
     status: 'TENTATIVE',
     uid: `${event.id}@cfa-cal`,
     productId: 'cfa-cal/ics',

--- a/src/models.ts
+++ b/src/models.ts
@@ -39,6 +39,11 @@ export interface CalendarEvent {
   tags: string[];               // any tags
   cover_img1: string;           // poster/cover image URL
 
+  // TMDb integration fields
+  tmdb_id: number | null;       // TMDb movie ID
+  imdb_id: string | null;       // IMDb ID (e.g., tt1234567)
+  tmdb_lookup_status: 'pending' | 'found' | 'not_found' | 'error';
+
   // Additional fields for our database
   date: string;                 // YYYY-MM-DD format
   day: number;                  // Day of month

--- a/src/services.ts
+++ b/src/services.ts
@@ -6,6 +6,7 @@
 
 import { fetchCalendar, isCalendarResponseValid, isLoginSuccessful, login } from './api-client';
 import type { CalendarDay, CalendarEvent, CalendarResponse, KVStorage } from './models';
+import { findMovieWithImdbId, TMDbRateLimitError } from './tmdb-client';
 import type { Env } from './types';
 import { AuthError, DatabaseError } from './utils/errors';
 
@@ -242,11 +243,13 @@ export class CalendarService {
   /**
    * Refresh calendar data for three months (previous, current, next)
    * Partial failures are tolerated - successful months are still stored
+   * Also enriches events with TMDb data if API key is configured
    */
   async refreshThreeMonthsCalendar(): Promise<{
     success: boolean;
     monthsRefreshed: number;
     monthsFailed: number;
+    tmdbEnriched: number;
   }> {
     const range = getThreeMonthRange();
     const months = [range.previous, range.current, range.next];
@@ -266,10 +269,14 @@ export class CalendarService {
       }
     }
 
+    // Enrich events with TMDb data after storing
+    const tmdbEnriched = await this.enrichPendingEventsWithTMDb();
+
     return {
       success: storedCount > 0,
       monthsRefreshed: storedCount,
       monthsFailed: fetchResult.failureCount + (fetchResult.successCount - storedCount),
+      tmdbEnriched,
     };
   }
 
@@ -402,8 +409,8 @@ export class CalendarService {
         show_time, show_price, screen_up_time, screen_sales_time,
         screen_start_time, program_colle, screen_cinema, activity,
         have_activity, tags, cover_img1, date, day, month, year,
-        created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        created_at, updated_at, tmdb_id, imdb_id, tmdb_lookup_status
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).bind(
       event.id,
       event.show_name,
@@ -432,7 +439,10 @@ export class CalendarService {
       eventDate.month,
       eventDate.year,
       timestamp,
-      timestamp
+      timestamp,
+      null, // tmdb_id - will be enriched later
+      null, // imdb_id - will be enriched later
+      'pending' // tmdb_lookup_status
     );
   }
 
@@ -444,6 +454,90 @@ export class CalendarService {
       `).bind('error', year, month, `Error: ${error}`, new Date().toISOString()).run();
     } catch {
       // Ignore logging errors
+    }
+  }
+
+  /**
+   * Enrich pending events with TMDb data (movie IDs)
+   * Processes up to maxEvents events per call to avoid rate limits
+   * @returns Number of events enriched
+   */
+  async enrichPendingEventsWithTMDb(maxEvents: number = 20): Promise<number> {
+    const apiKey = this.env.TMDB_API_KEY;
+
+    // Skip if no API key configured
+    if (!apiKey) {
+      console.log('[CalendarService] TMDb API key not configured, skipping enrichment');
+      return 0;
+    }
+
+    try {
+      // Get unique show names with pending lookup status
+      // Group by show_name to avoid duplicate API calls for the same movie
+      const pendingEvents = await this.env.DB.prepare(`
+        SELECT DISTINCT show_name, film_year
+        FROM calendar_events
+        WHERE tmdb_lookup_status = 'pending'
+        LIMIT ?
+      `).bind(maxEvents).all<{ show_name: string; film_year: string | null }>();
+
+      if (!pendingEvents.results?.length) {
+        return 0;
+      }
+
+      let enrichedCount = 0;
+
+      for (const event of pendingEvents.results) {
+        try {
+          const movieInfo = await findMovieWithImdbId(apiKey, event.show_name, event.film_year);
+
+          if (movieInfo) {
+            // Update all events with this show_name
+            await this.env.DB.prepare(`
+              UPDATE calendar_events
+              SET tmdb_id = ?, imdb_id = ?, tmdb_lookup_status = 'found', updated_at = ?
+              WHERE show_name = ? AND tmdb_lookup_status = 'pending'
+            `).bind(
+              movieInfo.tmdb_id,
+              movieInfo.imdb_id,
+              new Date().toISOString(),
+              event.show_name
+            ).run();
+
+            enrichedCount++;
+            console.log(`[CalendarService] Enriched "${event.show_name}" with TMDb ID: ${movieInfo.tmdb_id}`);
+          } else {
+            // Mark as not found
+            await this.env.DB.prepare(`
+              UPDATE calendar_events
+              SET tmdb_lookup_status = 'not_found', updated_at = ?
+              WHERE show_name = ? AND tmdb_lookup_status = 'pending'
+            `).bind(new Date().toISOString(), event.show_name).run();
+
+            console.log(`[CalendarService] No TMDb match for "${event.show_name}"`);
+          }
+        } catch (error) {
+          if (error instanceof TMDbRateLimitError) {
+            // Stop processing on rate limit, will continue next sync cycle
+            console.warn('[CalendarService] TMDb rate limit hit, stopping enrichment');
+            break;
+          }
+
+          // Mark as error for this specific movie
+          await this.env.DB.prepare(`
+            UPDATE calendar_events
+            SET tmdb_lookup_status = 'error', updated_at = ?
+            WHERE show_name = ? AND tmdb_lookup_status = 'pending'
+          `).bind(new Date().toISOString(), event.show_name).run();
+
+          console.error(`[CalendarService] TMDb error for "${event.show_name}":`, error);
+        }
+      }
+
+      return enrichedCount;
+    } catch (error) {
+      console.error('[CalendarService] TMDb enrichment failed:', error);
+      return 0;
     }
   }
 }

--- a/src/tmdb-client.ts
+++ b/src/tmdb-client.ts
@@ -1,0 +1,165 @@
+// TMDb API client for movie metadata enrichment
+// Fetches TMDb IDs and IMDB IDs for movie events
+
+const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
+const TMDB_TIMEOUT_MS = 5000;
+
+interface TMDbSearchResult {
+  id: number;
+  title: string;
+  original_title: string;
+  release_date: string;
+}
+
+interface TMDbSearchResponse {
+  results: TMDbSearchResult[];
+  total_results: number;
+}
+
+interface TMDbExternalIds {
+  imdb_id: string | null;
+  facebook_id: string | null;
+  instagram_id: string | null;
+  twitter_id: string | null;
+}
+
+export interface TMDbMovieInfo {
+  tmdb_id: number;
+  imdb_id: string | null;
+}
+
+/**
+ * Search for a movie on TMDb by title and optional year
+ */
+export async function searchMovie(
+  apiKey: string,
+  title: string,
+  year?: string | null
+): Promise<TMDbSearchResult | null> {
+  const params = new URLSearchParams({
+    api_key: apiKey,
+    query: title,
+    language: 'zh-CN',
+  });
+
+  if (year) {
+    params.set('year', year);
+  }
+
+  const url = `${TMDB_BASE_URL}/search/movie?${params}`;
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TMDB_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      if (response.status === 429) {
+        console.warn('[TMDb] Rate limited');
+        throw new TMDbRateLimitError('TMDb rate limit exceeded');
+      }
+      console.error(`[TMDb] Search failed: ${response.status}`);
+      return null;
+    }
+
+    const data: TMDbSearchResponse = await response.json();
+
+    if (data.results.length === 0) {
+      return null;
+    }
+
+    // Return the first (most relevant) result
+    return data.results[0];
+  } catch (error) {
+    if (error instanceof TMDbRateLimitError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === 'AbortError') {
+      console.error('[TMDb] Search timeout');
+    } else {
+      console.error('[TMDb] Search error:', error);
+    }
+    return null;
+  }
+}
+
+/**
+ * Get external IDs (IMDB, etc.) for a TMDb movie
+ */
+export async function getExternalIds(
+  apiKey: string,
+  tmdbId: number
+): Promise<TMDbExternalIds | null> {
+  const url = `${TMDB_BASE_URL}/movie/${tmdbId}/external_ids?api_key=${apiKey}`;
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TMDB_TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      if (response.status === 429) {
+        console.warn('[TMDb] Rate limited');
+        throw new TMDbRateLimitError('TMDb rate limit exceeded');
+      }
+      console.error(`[TMDb] External IDs failed: ${response.status}`);
+      return null;
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error instanceof TMDbRateLimitError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === 'AbortError') {
+      console.error('[TMDb] External IDs timeout');
+    } else {
+      console.error('[TMDb] External IDs error:', error);
+    }
+    return null;
+  }
+}
+
+/**
+ * Find a movie and get its TMDb ID and IMDB ID in one operation
+ */
+export async function findMovieWithImdbId(
+  apiKey: string,
+  title: string,
+  year?: string | null
+): Promise<TMDbMovieInfo | null> {
+  const movie = await searchMovie(apiKey, title, year);
+
+  if (!movie) {
+    return null;
+  }
+
+  const externalIds = await getExternalIds(apiKey, movie.id);
+
+  return {
+    tmdb_id: movie.id,
+    imdb_id: externalIds?.imdb_id || null,
+  };
+}
+
+/**
+ * Custom error for TMDb rate limiting
+ */
+export class TMDbRateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TMDbRateLimitError';
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface Env {
   // Environment variables for API access
   API_ACCOUNT: string;
   API_PASSWORD: string;
+  // TMDb API key (optional - if not set, TMDb enrichment is skipped)
+  TMDB_API_KEY?: string;
 }
 
 /**
@@ -35,5 +37,6 @@ declare global {
     DB: D1Database;
     API_ACCOUNT: string;
     API_PASSWORD: string;
+    TMDB_API_KEY?: string;
   }
 }

--- a/src/utils/movie-links.ts
+++ b/src/utils/movie-links.ts
@@ -1,0 +1,46 @@
+// Movie link generation utilities
+// Creates links to IMDB, Douban, and Letterboxd for movie events
+
+export interface MovieLinks {
+  imdb: string;
+  douban: string;
+  letterboxd: string;
+}
+
+/**
+ * Generate links to movie platforms
+ * Uses direct links when IMDB ID is available, otherwise falls back to search links
+ */
+export function generateMovieLinks(
+  showName: string,
+  filmYear: string | null,
+  imdbId: string | null
+): MovieLinks {
+  const encodedName = encodeURIComponent(showName);
+  const searchQuery = filmYear ? `${showName} ${filmYear}` : showName;
+  const encodedSearchQuery = encodeURIComponent(searchQuery);
+
+  return {
+    // Direct link if we have IMDB ID, otherwise search link
+    imdb: imdbId
+      ? `https://www.imdb.com/title/${imdbId}/`
+      : `https://www.imdb.com/find/?q=${encodedName}`,
+
+    // Douban doesn't have a public API for ID lookup, always use search
+    douban: `https://search.douban.com/movie/subject_search?search_text=${encodedName}`,
+
+    // Letterboxd uses title + year for better search results
+    letterboxd: `https://letterboxd.com/search/${encodedSearchQuery}/`,
+  };
+}
+
+/**
+ * Format movie links for ICS description
+ */
+export function formatMovieLinksForDescription(links: MovieLinks): string {
+  return [
+    `IMDB: ${links.imdb}`,
+    `豆瓣: ${links.douban}`,
+    `Letterboxd: ${links.letterboxd}`,
+  ].join('\n');
+}

--- a/test/setup/fixtures.ts
+++ b/test/setup/fixtures.ts
@@ -183,6 +183,9 @@ export const sampleEvents: CalendarEvent[] = [
     year: 2026,
     created_at: '2026-01-10T10:00:00Z',
     updated_at: '2026-01-10T10:00:00Z',
+    tmdb_id: 993846,
+    imdb_id: 'tt0Mo6332',
+    tmdb_lookup_status: 'found',
   },
   {
     id: 12346,
@@ -213,6 +216,9 @@ export const sampleEvents: CalendarEvent[] = [
     year: 2026,
     created_at: '2026-01-10T10:00:00Z',
     updated_at: '2026-01-10T10:00:00Z',
+    tmdb_id: null,
+    imdb_id: null,
+    tmdb_lookup_status: 'not_found',
   },
   {
     id: 12347,
@@ -243,6 +249,9 @@ export const sampleEvents: CalendarEvent[] = [
     year: 2026,
     created_at: '2026-01-10T10:00:00Z',
     updated_at: '2026-01-10T10:00:00Z',
+    tmdb_id: null,
+    imdb_id: null,
+    tmdb_lookup_status: 'pending',
   },
   {
     id: 12348,
@@ -273,6 +282,9 @@ export const sampleEvents: CalendarEvent[] = [
     year: 2026,
     created_at: '2026-01-10T10:00:00Z',
     updated_at: '2026-01-10T10:00:00Z',
+    tmdb_id: null,
+    imdb_id: null,
+    tmdb_lookup_status: 'pending',
   },
 ];
 

--- a/test/unit/movie-links.spec.ts
+++ b/test/unit/movie-links.spec.ts
@@ -1,0 +1,86 @@
+// Unit tests for src/utils/movie-links.ts
+
+import { describe, it, expect } from 'vitest';
+import { generateMovieLinks, formatMovieLinksForDescription } from '../../src/utils/movie-links';
+
+describe('movie-links', () => {
+  describe('generateMovieLinks()', () => {
+    it('should generate direct IMDB link when imdb_id is provided', () => {
+      const links = generateMovieLinks('The Matrix', '1999', 'tt0133093');
+
+      expect(links.imdb).toBe('https://www.imdb.com/title/tt0133093/');
+    });
+
+    it('should generate search IMDB link when imdb_id is null', () => {
+      const links = generateMovieLinks('The Matrix', '1999', null);
+
+      expect(links.imdb).toBe('https://www.imdb.com/find/?q=The%20Matrix');
+    });
+
+    it('should always generate Douban search link', () => {
+      const links = generateMovieLinks('霸王别姬', '1993', 'tt0106332');
+
+      expect(links.douban).toBe(
+        'https://search.douban.com/movie/subject_search?search_text=%E9%9C%B8%E7%8E%8B%E5%88%AB%E5%A7%AC'
+      );
+    });
+
+    it('should include year in Letterboxd search when provided', () => {
+      const links = generateMovieLinks('Inception', '2010', null);
+
+      expect(links.letterboxd).toBe('https://letterboxd.com/search/Inception%202010/');
+    });
+
+    it('should not include year in Letterboxd search when null', () => {
+      const links = generateMovieLinks('Inception', null, null);
+
+      expect(links.letterboxd).toBe('https://letterboxd.com/search/Inception/');
+    });
+
+    it('should properly encode special characters in movie names', () => {
+      const links = generateMovieLinks('Wall·E', '2008', null);
+
+      expect(links.imdb).toContain('Wall%C2%B7E');
+      expect(links.douban).toContain('Wall%C2%B7E');
+    });
+
+    it('should handle Chinese movie names', () => {
+      const links = generateMovieLinks('花样年华', '2000', null);
+
+      expect(links.imdb).toContain('%E8%8A%B1%E6%A0%B7%E5%B9%B4%E5%8D%8E');
+      expect(links.letterboxd).toContain('%E8%8A%B1%E6%A0%B7%E5%B9%B4%E5%8D%8E');
+    });
+
+    it('should handle movie names with spaces', () => {
+      const links = generateMovieLinks('The Dark Knight', '2008', null);
+
+      expect(links.imdb).toBe('https://www.imdb.com/find/?q=The%20Dark%20Knight');
+    });
+  });
+
+  describe('formatMovieLinksForDescription()', () => {
+    it('should format links with correct labels', () => {
+      const links = {
+        imdb: 'https://www.imdb.com/title/tt0133093/',
+        douban: 'https://search.douban.com/movie/subject_search?search_text=The%20Matrix',
+        letterboxd: 'https://letterboxd.com/search/The%20Matrix%201999/',
+      };
+
+      const formatted = formatMovieLinksForDescription(links);
+
+      expect(formatted).toBe(
+        'IMDB: https://www.imdb.com/title/tt0133093/\n' +
+        '豆瓣: https://search.douban.com/movie/subject_search?search_text=The%20Matrix\n' +
+        'Letterboxd: https://letterboxd.com/search/The%20Matrix%201999/'
+      );
+    });
+
+    it('should use newlines as separators', () => {
+      const links = generateMovieLinks('Test Movie', '2020', 'tt1234567');
+      const formatted = formatMovieLinksForDescription(links);
+
+      const lines = formatted.split('\n');
+      expect(lines).toHaveLength(3);
+    });
+  });
+});

--- a/test/unit/tmdb-client.spec.ts
+++ b/test/unit/tmdb-client.spec.ts
@@ -1,0 +1,227 @@
+// Unit tests for src/tmdb-client.ts
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createMockFetch } from '../setup/mocks';
+import {
+  searchMovie,
+  getExternalIds,
+  findMovieWithImdbId,
+  TMDbRateLimitError,
+} from '../../src/tmdb-client';
+
+describe('TMDb Client', () => {
+  let mockFetch: ReturnType<typeof createMockFetch>;
+
+  beforeEach(() => {
+    mockFetch = createMockFetch();
+    vi.stubGlobal('fetch', mockFetch.mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockFetch.reset();
+  });
+
+  describe('searchMovie()', () => {
+    it('should send GET request to TMDb search endpoint', async () => {
+      mockFetch.setResponse(/api.themoviedb.org/, new Response(JSON.stringify({
+        results: [{ id: 603, title: 'The Matrix', original_title: 'The Matrix', release_date: '1999-03-30' }],
+        total_results: 1,
+      })));
+
+      await searchMovie('test-api-key', 'The Matrix', '1999');
+
+      const calls = mockFetch.getCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toContain('api.themoviedb.org/3/search/movie');
+      expect(calls[0].url).toContain('api_key=test-api-key');
+      // URLSearchParams encodes spaces as + instead of %20
+      expect(calls[0].url).toContain('query=The+Matrix');
+      expect(calls[0].url).toContain('year=1999');
+    });
+
+    it('should not include year param when not provided', async () => {
+      mockFetch.setResponse(/api.themoviedb.org/, new Response(JSON.stringify({
+        results: [],
+        total_results: 0,
+      })));
+
+      await searchMovie('test-api-key', 'The Matrix');
+
+      const calls = mockFetch.getCalls();
+      expect(calls[0].url).not.toContain('year=');
+    });
+
+    it('should return first search result on success', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [
+          { id: 603, title: 'The Matrix', original_title: 'The Matrix', release_date: '1999-03-30' },
+          { id: 604, title: 'The Matrix Reloaded', original_title: 'The Matrix Reloaded', release_date: '2003-05-07' },
+        ],
+        total_results: 2,
+      })));
+
+      const result = await searchMovie('key', 'The Matrix');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(603);
+      expect(result?.title).toBe('The Matrix');
+    });
+
+    it('should return null when no results found', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [],
+        total_results: 0,
+      })));
+
+      const result = await searchMovie('key', 'Nonexistent Movie Title 12345');
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw TMDbRateLimitError on 429 response', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response('Rate limit exceeded', { status: 429 }));
+
+      await expect(searchMovie('key', 'Test')).rejects.toThrow(TMDbRateLimitError);
+    });
+
+    it('should return null on other HTTP errors', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response('Server error', { status: 500 }));
+
+      const result = await searchMovie('key', 'Test');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null on network error', async () => {
+      mockFetch.setResponse(/search\/movie/, () => {
+        throw new Error('Network error');
+      });
+
+      const result = await searchMovie('key', 'Test');
+
+      expect(result).toBeNull();
+    });
+
+    it('should set language to zh-CN', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [],
+        total_results: 0,
+      })));
+
+      await searchMovie('key', 'Test');
+
+      const calls = mockFetch.getCalls();
+      expect(calls[0].url).toContain('language=zh-CN');
+    });
+  });
+
+  describe('getExternalIds()', () => {
+    it('should send GET request to external_ids endpoint', async () => {
+      mockFetch.setResponse(/external_ids/, new Response(JSON.stringify({
+        imdb_id: 'tt0133093',
+        facebook_id: null,
+        instagram_id: null,
+        twitter_id: null,
+      })));
+
+      await getExternalIds('test-key', 603);
+
+      const calls = mockFetch.getCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toContain('api.themoviedb.org/3/movie/603/external_ids');
+      expect(calls[0].url).toContain('api_key=test-key');
+    });
+
+    it('should return external IDs on success', async () => {
+      mockFetch.setResponse(/external_ids/, new Response(JSON.stringify({
+        imdb_id: 'tt0133093',
+        facebook_id: 'TheMatrixMovie',
+        instagram_id: null,
+        twitter_id: null,
+      })));
+
+      const result = await getExternalIds('key', 603);
+
+      expect(result).not.toBeNull();
+      expect(result?.imdb_id).toBe('tt0133093');
+      expect(result?.facebook_id).toBe('TheMatrixMovie');
+    });
+
+    it('should throw TMDbRateLimitError on 429 response', async () => {
+      mockFetch.setResponse(/external_ids/, new Response('Rate limit exceeded', { status: 429 }));
+
+      await expect(getExternalIds('key', 603)).rejects.toThrow(TMDbRateLimitError);
+    });
+
+    it('should return null on other HTTP errors', async () => {
+      mockFetch.setResponse(/external_ids/, new Response('Not found', { status: 404 }));
+
+      const result = await getExternalIds('key', 99999999);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findMovieWithImdbId()', () => {
+    it('should return tmdb_id and imdb_id when movie is found', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [{ id: 603, title: 'The Matrix', original_title: 'The Matrix', release_date: '1999-03-30' }],
+        total_results: 1,
+      })));
+      mockFetch.setResponse(/external_ids/, new Response(JSON.stringify({
+        imdb_id: 'tt0133093',
+        facebook_id: null,
+        instagram_id: null,
+        twitter_id: null,
+      })));
+
+      const result = await findMovieWithImdbId('key', 'The Matrix', '1999');
+
+      expect(result).not.toBeNull();
+      expect(result?.tmdb_id).toBe(603);
+      expect(result?.imdb_id).toBe('tt0133093');
+    });
+
+    it('should return null when movie is not found in search', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [],
+        total_results: 0,
+      })));
+
+      const result = await findMovieWithImdbId('key', 'Nonexistent Movie');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return tmdb_id with null imdb_id when external_ids fails', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [{ id: 603, title: 'The Matrix', original_title: 'The Matrix', release_date: '1999-03-30' }],
+        total_results: 1,
+      })));
+      mockFetch.setResponse(/external_ids/, new Response('Server error', { status: 500 }));
+
+      const result = await findMovieWithImdbId('key', 'The Matrix');
+
+      expect(result).not.toBeNull();
+      expect(result?.tmdb_id).toBe(603);
+      expect(result?.imdb_id).toBeNull();
+    });
+
+    it('should propagate TMDbRateLimitError from search', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response('Rate limited', { status: 429 }));
+
+      await expect(findMovieWithImdbId('key', 'Test')).rejects.toThrow(TMDbRateLimitError);
+    });
+
+    it('should propagate TMDbRateLimitError from external_ids', async () => {
+      mockFetch.setResponse(/search\/movie/, new Response(JSON.stringify({
+        results: [{ id: 603, title: 'The Matrix', original_title: 'The Matrix', release_date: '1999-03-30' }],
+        total_results: 1,
+      })));
+      mockFetch.setResponse(/external_ids/, new Response('Rate limited', { status: 429 }));
+
+      await expect(findMovieWithImdbId('key', 'The Matrix')).rejects.toThrow(TMDbRateLimitError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Integrate TMDb API to fetch movie metadata (TMDb ID, IMDB ID)
- Add direct IMDB links when available, with search link fallbacks
- Include links to IMDB, Douban, and Letterboxd in ICS event descriptions

## Changes
- **New files:**
  - `src/tmdb-client.ts` - TMDb API client with rate limit handling
  - `src/utils/movie-links.ts` - Link generation utilities
  - Unit tests for both modules
- **Modified:**
  - `schema.sql` - Added `tmdb_id`, `imdb_id`, `tmdb_lookup_status` columns
  - `src/models.ts` - Updated `CalendarEvent` interface
  - `src/services.ts` - Added `enrichPendingEventsWithTMDb()` method
  - `src/calendar.ts` - Include movie links in ICS description
  - `src/types.ts` - Added optional `TMDB_API_KEY` to Env

## Test plan
- [x] All 271 tests pass
- [x] TypeScript compiles without errors
- [x] TMDb API key verified working
- [ ] Deploy and verify ICS contains movie links
- [ ] Set `TMDB_API_KEY` secret in production

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)